### PR TITLE
this allows tensorflow to use CUDA if running on a linux host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.7.7-buster
+FROM tensorflow/tensorflow:2.2.0-gpu
+
 WORKDIR /app
 COPY . .
 RUN pip install -r requirements.txt


### PR DESCRIPTION
The Linux host needs CUDA installed as well, to run with CUDA support pass `--gpus=all` to the `docker run` command. This can also be run in the same way as before without the CUDA support by not passing the `--gpus` argument to Docker.